### PR TITLE
follow redirects in curl

### DIFF
--- a/admin/functions.php
+++ b/admin/functions.php
@@ -102,6 +102,7 @@ function rest_get($req)
       $cURLConnection = curl_init();
       curl_setopt($cURLConnection, CURLOPT_URL, $protocol . $_SERVER['HTTP_HOST'] . $req);
       curl_setopt($cURLConnection, CURLOPT_RETURNTRANSFER, true);
+      curl_setopt($cURLConnection, CURLOPT_FOLLOWLOCATION, true);
 
       $result = curl_exec($cURLConnection);
 


### PR DESCRIPTION
When running in Docker this function tries to curl as http but is redirected to https. This change will let it follow that redirect.