### PR TITLE
allow rest to return unbound arks with non-digits

### DIFF
--- a/admin/rest.php
+++ b/admin/rest.php
@@ -474,7 +474,7 @@ function selectBound()
   // sql which gets all bound arks 
   $sql_boundarks = "SELECT id, REPLACE (id, '$firstpart', '') as _id
       from (
-          SELECT DISTINCT SUBSTRING_INDEX(_key, '\t', 1) AS id
+          SELECT DISTINCT REGEXP_SUBSTR(_key, '".$firstpart."[[:digit:][:alpha:]]+(\\t[/.]*.*\\t)*') AS id
               FROM `<table-name>`
               WHERE _key LIKE '$firstpart%' 
               AND (_key NOT REGEXP '\\\\s:\\/c' AND _key NOT REGEXP '\\\\s:\\/h') 

--- a/admin/rest.php
+++ b/admin/rest.php
@@ -474,7 +474,7 @@ function selectBound()
   // sql which gets all bound arks 
   $sql_boundarks = "SELECT id, REPLACE (id, '$firstpart', '') as _id
       from (
-          SELECT DISTINCT REGEXP_SUBSTR(_key, '".$firstpart."[[:digit:]]+(\\t[/.]*.*\\t)*') AS id
+          SELECT DISTINCT SUBSTRING_INDEX(_key, '\t', 1) AS id
               FROM `<table-name>`
               WHERE _key LIKE '$firstpart%' 
               AND (_key NOT REGEXP '\\\\s:\\/c' AND _key NOT REGEXP '\\\\s:\\/h') 


### PR DESCRIPTION
The DB query was set to truncate bound arks after the first non-digit, which would truncate arks with letters in them incorrectly. This updates it to truncate at the tab character instead.